### PR TITLE
[feat] Apple OAuth 기능 개발

### DIFF
--- a/src/main/java/devholic/library/oauth2/apple/AppleTokenAgent.java
+++ b/src/main/java/devholic/library/oauth2/apple/AppleTokenAgent.java
@@ -1,0 +1,26 @@
+package devholic.library.oauth2.apple;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class AppleTokenAgent {
+
+    public static String getUserResource(String appleToken) {
+
+        String[] parts = appleToken.split("\\.");
+        String payload = parts[1];
+
+        String decodedPayload = new String(Base64.getDecoder().decode(payload), StandardCharsets.UTF_8);
+
+        String payloadJson = decodedPayload.substring(1, decodedPayload.length() - 1);
+        String[] jsonArray = payloadJson.split(",");
+        for (String json : jsonArray) {
+            String[] each = json.split(":");
+            String key = each[0].substring(1, each[0].length() - 1);
+            String value = each[1].substring(1, each[1].length() - 1);
+            if (key.equals("email"))
+                return value;
+        }
+        return "fail";
+    }
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 애플 OAuth를 통해 이메일 정보 가져오는 기능을 개발

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
* 클라이언트에서 애플 유저에 대한 JWT를 제공해주면, 직접 파싱하여 이메일을 추출하는 기능입니다.
* 클라이언트가 요청하는 방법으로는 크게 fragment 방식과 form_post 방식이 있는데, form_post 방식을 할 경우에는 이메일 뿐 아니라 유저의 이름 등에 대한 정보도 가져올 수 있습니다. 하지만 cors 등의 문제가 제대로 해결되지 않았다면 리다이렉트 경로도 잘못 전달되어 form_post 방식에서는 응답 값들을 가져올 수 없습니다. 그래서 일단은 fragment 방식으로 리턴되도록 하여 URL 상으로 직접 id_token을 얻도록 하였습니다.
## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->

## Issue 👀
<!-- 관련 이슈를 연결합니다. #48 등과 같이 입력해주세요! -->